### PR TITLE
rename borderWidth to cborderWidth

### DIFF
--- a/checkbox/Checkbox.swift
+++ b/checkbox/Checkbox.swift
@@ -57,7 +57,7 @@ public class Checkbox: UIControl {
     /// in order appear similar next to other border styles.
     ///
     /// **Default:** `2`
-    public var borderWidth: CGFloat = 2
+    public var cborderWidth: CGFloat = 2
 
     /// Size of the center checkmark element.
     ///
@@ -139,10 +139,10 @@ public class Checkbox: UIControl {
     // MARK: - Borders
 
     private func drawBorder(shape: BorderStyle, in rect: CGRect) {
-        let adjustedRect = CGRect(x: borderWidth/2,
-                                  y: borderWidth/2,
-                                  width: rect.width-borderWidth,
-                                  height: rect.height-borderWidth)
+        let adjustedRect = CGRect(x: cborderWidth/2,
+                                  y: cborderWidth/2,
+                                  width: rect.width-cborderWidth,
+                                  height: rect.height-cborderWidth)
 
         switch shape {
         case .circle:
@@ -161,7 +161,7 @@ public class Checkbox: UIControl {
             uncheckedBorderColor.setStroke()
         }
 
-        rectanglePath.lineWidth = borderWidth
+        rectanglePath.lineWidth = cborderWidth
         rectanglePath.stroke()
         checkboxBackgroundColor.setFill()
         rectanglePath.fill()
@@ -176,7 +176,7 @@ public class Checkbox: UIControl {
             uncheckedBorderColor.setStroke()
         }
 
-        ovalPath.lineWidth = borderWidth / 2
+        ovalPath.lineWidth = cborderWidth / 2
         ovalPath.stroke()
         checkboxBackgroundColor.setFill()
         ovalPath.fill()

--- a/checkbox/Checkbox.swift
+++ b/checkbox/Checkbox.swift
@@ -57,7 +57,7 @@ public class Checkbox: UIControl {
     /// in order appear similar next to other border styles.
     ///
     /// **Default:** `2`
-    public var cborderWidth: CGFloat = 2
+    public var checkboxBorderWidth: CGFloat = 2
 
     /// Size of the center checkmark element.
     ///
@@ -139,10 +139,10 @@ public class Checkbox: UIControl {
     // MARK: - Borders
 
     private func drawBorder(shape: BorderStyle, in rect: CGRect) {
-        let adjustedRect = CGRect(x: cborderWidth/2,
-                                  y: cborderWidth/2,
-                                  width: rect.width-cborderWidth,
-                                  height: rect.height-cborderWidth)
+        let adjustedRect = CGRect(x: checkboxBorderWidth/2,
+                                  y: checkboxBorderWidth/2,
+                                  width: rect.width-checkboxBorderWidth,
+                                  height: rect.height-checkboxBorderWidth)
 
         switch shape {
         case .circle:
@@ -176,7 +176,7 @@ public class Checkbox: UIControl {
             uncheckedBorderColor.setStroke()
         }
 
-        ovalPath.lineWidth = cborderWidth / 2
+        ovalPath.lineWidth = checkboxBorderWidth / 2
         ovalPath.stroke()
         checkboxBackgroundColor.setFill()
         ovalPath.fill()

--- a/demo/ViewController.swift
+++ b/demo/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
         let circleBox = Checkbox(frame: CGRect(x: 30, y: 40, width: 25, height: 25))
         circleBox.borderStyle = .circle
         circleBox.checkmarkStyle = .circle
-        circleBox.borderWidth = 1
+        circleBox.cborderWidth = 1
         circleBox.uncheckedBorderColor = .lightGray
         circleBox.checkedBorderColor = .blue
         circleBox.checkmarkSize = 0.8
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
         squareBox.borderStyle = .square
         squareBox.checkmarkStyle = .square
         squareBox.uncheckedBorderColor = .lightGray
-        squareBox.borderWidth = 1
+        squareBox.cborderWidth = 1
         squareBox.valueChanged = { (value) in
             print("square checkbox value change: \(value)")
         }


### PR DESCRIPTION
This library does what it says. But I have found a little collateral... 
The property borderWidth clashes with swiftutilities. 

It's pretty difficult to handle this without changing the dependency code.
